### PR TITLE
Smaller screen width (default) when opening the overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ if (require('electron-squirrel-startup')) return app.quit();
 app.once('ready', () => {
   const { width } = electron.screen.getPrimaryDisplay().workAreaSize
   window = new BrowserWindow({
-    width: 750,
+    width: 650,
     height: 460,
     transparent: true,
     x: width - 750,


### PR DESCRIPTION
So I made the default screen width for the overlay 650x460 (the same height) because I feel like 760 was a bit too much for people with just 1 monitor (they can't move the overlay to there 2nd monitor) I'm not sure if this will help but I can always turn the width down anyways here is a screenshot of the new 650x460 window which I ran locally on my pc:  https://cdn.discordapp.com/attachments/767819431241056291/772566743323377704/Statsify_Overlay_2020-11-01_4_02_26_PM.png anyways lmk what you think I didn't check how it was with actual data but I think it will ok