### PR TITLE
Fix for decimal level being incorrect for levels < 4

### DIFF
--- a/utils/bedwars.js
+++ b/utils/bedwars.js
@@ -22,7 +22,7 @@ const getBwLevel = (exp = 0) => {
         remainingExp -= expForNextLevel
     }
 
-    return parseFloat((level + (remainingExp / 5000)).toFixed(2))
+    return parseFloat((level + (remainingExp / getBwExpForLevel(level + 1))).toFixed(2))
 }
 
 const getBwFormattedLevel = star => {


### PR DESCRIPTION
Decimal was being calculated as remainingExp / 5000, but that won't be accurate when the exp to the next level isn't 5000, such as at the lower levels.

Fix for #6 